### PR TITLE
fix wrong extension name usage in translate

### DIFF
--- a/Classes/Utility/ModuleUtility.php
+++ b/Classes/Utility/ModuleUtility.php
@@ -34,6 +34,11 @@ class ModuleUtility
     static public $extensionName = '';
 
     /**
+     * @var array
+     */
+    static public $extensionNameMap = [];
+
+    /**
      * @param string $extensionName
      * @throws \Exception
      */
@@ -45,6 +50,11 @@ class ModuleUtility
 
         if (!is_array($GLOBALS['TYPO3_CONF_VARS']['EXT']['fbit_berecordlist']['modules'][$extensionName])) {
             throw new \Exception('There seems to be no configuration available for EXT:' . $extensionName . '. Please refer to the README for more details.', 1500032366);
+        }
+
+        if (isset($GLOBALS['TYPO3_CONF_VARS']['EXT']['fbit_berecordlist']['modules'][$extensionName]['originalExtensionName'])) {
+            $originalExtensionName = $GLOBALS['TYPO3_CONF_VARS']['EXT']['fbit_berecordlist']['modules'][$extensionName]['originalExtensionName'];
+            self::$extensionNameMap[$extensionName] = $originalExtensionName;
         }
 
         self::$extensionName = $extensionName;
@@ -86,6 +96,11 @@ class ModuleUtility
     static public function translate(string $key, string $extension): string
     {
         $ll = self::$moduleConfig['labels'];
+
+        if (isset(self::$extensionNameMap[$extension])) {
+            $extension = self::$extensionNameMap[$extension];
+        }
+
         return LocalizationUtility::translate($ll . ':' . $key, $extension);
     }
 


### PR DESCRIPTION
I have add a new config for a extension name aliases.

the config looks like: 
```
$GLOBALS['TYPO3_CONF_VARS']['EXT']['fbit_berecordlist']['modules'][$extKey] = [
            'originalExtensionName' => $extKey
];

$GLOBALS['TYPO3_CONF_VARS']['EXT']['fbit_berecordlist']['modules'][$extKey . '_virtualSubModule'] = $GLOBALS['TYPO3_CONF_VARS']['EXT']['fbit_berecordlist']['modules'][$extKey];
```

the problem was, $extKey . '_virtualSubModule' doesn't exist for the translation utility as a valid extension.