### PR TITLE
Fix/language translate Null exception

### DIFF
--- a/Classes/Utility/ModuleUtility.php
+++ b/Classes/Utility/ModuleUtility.php
@@ -93,7 +93,7 @@ class ModuleUtility
         $ll = self::$moduleConfig['labels'];
         $translated = LocalizationUtility::translate($ll . ':' . $key, $extension);
         // translated can be null
-        return ($translated === null)?$translated:'';
+        return ($translated !== null)?$translated:$key;
     }
 
     /**

--- a/Classes/Utility/ModuleUtility.php
+++ b/Classes/Utility/ModuleUtility.php
@@ -83,10 +83,17 @@ class ModuleUtility
         );
     }
 
+    /**
+     * @param string $key
+     * @param string $extension
+     * @return string
+     */
     static public function translate(string $key, string $extension): string
     {
         $ll = self::$moduleConfig['labels'];
-        return LocalizationUtility::translate($ll . ':' . $key, $extension);
+        $translated = LocalizationUtility::translate($ll . ':' . $key, $extension);
+        // translated can be null
+        return ($translated === null)?$translated:'';
     }
 
     /**


### PR DESCRIPTION
This will fix the type typeHinting error for the translate method.

the core translation utility returns both, Null or a string
the static method can only return valid strings ;)